### PR TITLE
Fix out of memory error by calling garbege collection when bitmap is cle...

### DIFF
--- a/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -298,6 +298,7 @@ public class ShowcaseView extends RelativeLayout
         if (bitmapBuffer != null && !bitmapBuffer.isRecycled()) {
             bitmapBuffer.recycle();
             bitmapBuffer = null;
+            System.gc();
         }
     }
 


### PR DESCRIPTION
複数枚のコーチマークを切り替えて表示する画面で、`Bitmap.createBitmap()`が`OutOfMemoryError`でクラッシュします。
`clearBitmap()`で`recycle()`した後に念のためガベージコレクションを走らせます。
